### PR TITLE
Updating for Pants 1.4.0rc1

### DIFF
--- a/src/python/verst/pants/s3cache/BUILD
+++ b/src/python/verst/pants/s3cache/BUILD
@@ -18,7 +18,7 @@ python_library(
     name='verst.pants.s3cache',
     maintainer="Todd Gardner",
     maintainer_email="todd.gardner@gmail.com",
-	version='1.2.0',
+	version='1.4.0',
 	url='https://github.com/toddgardner/pants-plugins',
 	description='An S3 caching backend for pants artifact cache',
 	license='MIT',

--- a/src/python/verst/pants/s3cache/cache_setup.py
+++ b/src/python/verst/pants/s3cache/cache_setup.py
@@ -43,7 +43,7 @@ def _do_create_artifact_cache(self, spec, action):
   artifact_root = self._options.pants_workdir
 
   def create_local_cache(parent_path):
-    path = os.path.join(parent_path, self._task.stable_name())
+    path = os.path.join(parent_path, self._cache_dirname)
     self._log.debug('{0} {1} local artifact cache at {2}'
                     .format(self._task.stable_name(), action, path))
     return LocalArtifactCache(artifact_root, path, compression,
@@ -62,7 +62,7 @@ def _do_create_artifact_cache(self, spec, action):
 
     urls = self.get_available_urls(urls)
     if len(urls) > 0:
-      best_url_selector = BestUrlSelector(['{}/{}'.format(url.rstrip('/'), self._task.stable_name())
+      best_url_selector = BestUrlSelector(['{}/{}'.format(url.rstrip('/'), self._cache_dirname)
                                             for url in urls])
       return RESTfulArtifactCache(artifact_root, best_url_selector, local_cache)
 

--- a/src/python/verst/pants/s3cache/cache_setup.py
+++ b/src/python/verst/pants/s3cache/cache_setup.py
@@ -43,9 +43,9 @@ def _do_create_artifact_cache(self, spec, action):
   artifact_root = self._options.pants_workdir
 
   def create_local_cache(parent_path):
-    path = os.path.join(parent_path, self._stable_name)
+    path = os.path.join(parent_path, self._task.stable_name())
     self._log.debug('{0} {1} local artifact cache at {2}'
-                    .format(self._stable_name, action, path))
+                    .format(self._task.stable_name(), action, path))
     return LocalArtifactCache(artifact_root, path, compression,
                               self._options.max_entries_per_target,
                               permissions=self._options.write_permissions,
@@ -62,7 +62,7 @@ def _do_create_artifact_cache(self, spec, action):
 
     urls = self.get_available_urls(urls)
     if len(urls) > 0:
-      best_url_selector = BestUrlSelector(['{}/{}'.format(url.rstrip('/'), self._stable_name)
+      best_url_selector = BestUrlSelector(['{}/{}'.format(url.rstrip('/'), self._task.stable_name())
                                             for url in urls])
       return RESTfulArtifactCache(artifact_root, best_url_selector, local_cache)
 


### PR DESCRIPTION
The `_stable_name` attribute on `CacheFactory` was moved into the `_task` attribute, and `_cache_dirname` was added

That commit is [here](https://github.com/pantsbuild/pants/commit/0bbe913f1c67f298b3191ed51498b20144536888#diff-2fc138b0f7b816c86d8749e366f535c6)