### PR TITLE
Skip max_entries_per_target check

### DIFF
--- a/src/python/verst/pants/s3cache/cache_setup.py
+++ b/src/python/verst/pants/s3cache/cache_setup.py
@@ -50,12 +50,17 @@ def _do_create_artifact_cache(self, spec, action):
         self._log.debug(
           "{0} {1} local artifact cache at {2}".format(self._task.stable_name(), action, path)
         )
+        if self._options.max_entries_per_target is None or self._options.max_entries_per_target < 0:
+          max_entries_per_target = None
+        else:
+          max_entries_per_target = self._options.max_entries_per_target
+
         return LocalArtifactCache(
           artifact_root,
           artifact_extraction_root,
           path,
           compression,
-          self._options.max_entries_per_target,
+          max_entries_per_target,
           permissions=self._options.write_permissions,
           dereference=self._options.dereference_symlinks,
         )


### PR DESCRIPTION
We want to skip the `max_entries_per_target` check because its very expensive. However it looks like https://github.com/pantsbuild/pants/blob/1.27.x/src/python/pants/cache/local_artifact_cache.py#L119-L153 doesnt let you skip it unless you pass "None" from pants.ini. And I dont believe you can really pass "None".

So adding support here, if the value is negative, we skip it.